### PR TITLE
Wait for goal by default. Fire&forget is optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ axcli
 
 A simple actionlib CLI client
 
-
 How to use
 ----------
 
@@ -11,18 +10,21 @@ Add this package in your `catkin` workspace, don't forget to
 source your `devel/setup.bash` after running `catkin_make`
 
 ```shell
-axcli <action server> <goal> [--wait]
+axcli [--nowait] [--timeout TIMEOUT] [-v] <action namespace> <goal>
 ```
 
 Bash should provide TAB-completion of available action
 servers and their associated goals.
+By default `axcli` will wait for the goal to terminate, and pressing
+<kbd>Ctrl+c</kbd> will send a goal cancel request to the action
+server.
 
-Unless `--wait` is specified, the program will return immediately
-after sending the goal to the action server, without waiting for
-any feedback or result.
+The following optional arguments are available to change
+`axcli`'s behavior:
 
-If `--wait` is specified, `axcli` will wait for the goal to
-terminate. Pressing 
-<kbd>Ctrl+c</kbd>
-will send a goal cancel request
-to the action server.
+* `--nowait` don't wait for result, fire and forget.
+
+* `--timeout` timeout in seconds used to wait for the action server
+               (default: infinite timeout).
+
+* `-v, --verbose` verbose output.

--- a/bin/axcli
+++ b/bin/axcli
@@ -83,7 +83,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Send a goal to an action server')
     parser.add_argument('action_name', help='name of the action')
     parser.add_argument('goal', help='contents of the goal')
-    parser.add_argument('--wait', action='store_true', help='wait for result')
+    parser.add_argument('--nowait', action='store_true', help="don't wait for result, fire and forget")
     parser.add_argument('--timeout', type=float, default=0.0,
                         help='timeout in seconds used to wait for the action server (default: infinite timeout)')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose output')
@@ -111,7 +111,9 @@ if __name__ == "__main__":
         sys.exit(1)
     goal = da.fill_goal(yaml.load(args.goal))
     alc.send_goal(goal)
-    if args.wait:
+    if args.nowait:
+        if args.verbose: printc('goal sent to action server', 'bright cyan')
+    else:
         def cancel(signum, frame):
             alc.cancel_goal()
             rospy.signal_shutdown("goal canceled")
@@ -128,5 +130,3 @@ if __name__ == "__main__":
           else:
             print_err("goal finished with state {}".format(GoalStatus.to_string(alc.get_state())))
           sys.exit(1)
-    else:
-        if args.verbose: printc('goal sent to action server', 'bright cyan')


### PR DESCRIPTION
- The CLI option --wait has been replaced with --nowait.
